### PR TITLE
Add support for encoding data tags and fix "Unhandled kind uint8" error

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -86,6 +86,13 @@ func (e *encoder) writeValue(v reflect.Value) {
 		}
 		return
 	case reflect.Slice:
+		if (reflect.Kind(v.Type().Elem().Kind()) == reflect.Uint8) {
+			s := []byte(v.Bytes())
+			e.tag(4, len(s))
+			e.buf.Write(s) 
+			return
+		}
+
 		l := v.Len()
 		e.tag(10, l)
 		for i := 0; i < l; i++ {


### PR DESCRIPTION
This pull request adds support for marshalling `data` tags. If a property list file contained these tags an "Unhandled kind uint8" error message would be output in addition to an unparseable file.

The following code can be used to verify this:

```
package main

import (
  "fmt"
  "io/ioutil"
  "os"
  "plist"
)

type KCEntry struct {
  Data []byte `plist:"v_Data"`
  Ref  []byte `plist:"v_PersistentRef"`
}

type Keychain struct {
  Internet []KCEntry `plist:"inet"`
  General  []KCEntry `plist:"genp"`
  Certs    []KCEntry `plist:"cert"`
  Keys     []KCEntry `plist:"keys"`
}

func must(err error) {
  if err != nil {
    fmt.Println(err)
    os.Exit(-1)
  }
}

func main() {
  fname := "keychain-backup.plist"
  f, err := os.Open(fname)
  must(err)

  var v Keychain
  err = plist.Unmarshal(f, &v)
  must(err)
  
  out, err := plist.Marshal(v)
  must(err)

  err = ioutil.WriteFile(fname, out, 0644)

  must(err)
}
```
[keychain-backup.plist.zip](https://github.com/dunhamsteve/plist/files/7699949/keychain-backup.plist.zip)